### PR TITLE
Add www to host in production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   }
 
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default_url_options = { :host => 'sledsheet.com' }
+  config.action_mailer.default_url_options = { :host => 'www.sledsheet.com' }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
An experiment to test if leaving 'www' out of my domain in production.rb causes my mailers to fail. 
