### PR TITLE
Add administrative options to invites

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -2,6 +2,14 @@ class Admin::InvitationsController < AdminController
 
   def index
     @invitations = Invitation.waitlist
+    @pending = Invitation.pending
+    @claimed = Invitation.claimed
+  end
+
+  def destroy
+    Invitation.find(params[:id]).destroy
+    flash[:success] = "Invitation has been revoked."
+    redirect_to admin_invitations_path
   end
 
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -8,6 +8,7 @@ class InvitationsController < ApplicationController
 
   def waitlist
     @invitation = Invitation.new(invitation_params)
+    @invitation.status = "waitlist"
     if @invitation.save
       flash[:success] = "Thanks, we've added you to the waitlist."
       redirect_to root_path

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -10,7 +10,11 @@ class Invitation < ActiveRecord::Base
 
   before_create :generate_token
 
-  scope :waitlist, -> {where(sender_id: nil)}
+  enum status: [:pending, :claimed, :waitlist]
+
+  scope :pending, -> {where(status: 0)}
+  scope :claimed, -> {where(status: 1)}
+  scope :waitlist, -> {where(status: 2)}
 
   private
 

--- a/app/views/admin/invitations/index.html.erb
+++ b/app/views/admin/invitations/index.html.erb
@@ -1,8 +1,36 @@
-<table class="table table-bordered">
-  <% @invitations.each do |invitation| %>
-  <tr>
-    <td><%= invitation.recipient_email %></td>
-    <td><%= link_to 'Send Invite', invitation_path(invitation), method: :patch %></td>
-  </tr>
-  <% end %>
-</table>
+<p><%= link_to 'Send an invitation', new_invitation_path, class: 'btn btn-success'%></p>
+
+<div class="row">
+  <div class="col-sm-4">
+    <h3>Waitlist</h3>
+    <table class="table table-bordered">
+      <% @invitations.each do |invitation| %>
+      <tr>
+        <td><%= invitation.recipient_email %></td>
+        <td><%= link_to 'Send Invite', invitation_path(invitation), method: :patch %> or <%= link_to "Remove", admin_invitation_path(invitation), method: :delete, data: { confirm: "You sure?" }, class: 'text-danger' %></td>
+      </tr>
+      <% end %>
+    </table>
+  </div>
+  <div class="col-sm-4">
+    <h3>Pending</h3>
+    <table class="table table-bordered">
+      <% @pending.each do |invitation| %>
+      <tr>
+        <td><%= invitation.recipient_email %></td>
+        <td><%= link_to 'Re-send Invite', invitation_path(invitation), method: :patch %> (#TODO) or <%= link_to "Revoke", admin_invitation_path(invitation), method: :delete, data: { confirm: "You sure?" }, class: 'text-danger' %> </td>
+      </tr>
+      <% end %>
+    </table>
+  </div>
+  <div class="col-sm-4">
+    <h3>Claimed</h3>
+    <table class="table table-bordered">
+      <% @claimed.each do |invitation| %>
+      <tr>
+        <td><%= invitation.recipient_email %></td>
+      </tr>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -36,7 +36,7 @@
                 <% if current_user.admin? %>
                   <li class="divider"></li>
                   <li class="dropdown-header">ADMIN</li>
-                  <li><%= link_to "Invite", new_invitation_path %></li>
+                  <li><%= link_to "Invitations", admin_invitations_path %></li>
                   <li><%= link_to "Users", admin_users_path %></li>
                   <li><%= link_to "Tracks", admin_tracks_path %></li>
                   <li><%= link_to "Circuits", admin_circuits_path %></li>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -8,7 +8,7 @@
       <p>Sledsheet will be available in October 2015. If you'd like to sign up for the closed beta, please add your email below.</p>
       <%= form_for Invitation.new, url: waitlist_path do |f| %>
         <%= f.text_field :recipient_email, placeholder: 'email address' %>
-        <%= f.submit %>
+        <%= f.submit 'Request Invitation' %>
       <% end %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
     resources :circuits
     resources :points
     resources :runs, only: :index
-    resources :invitations, only: :index
+    resources :invitations, only: [:index, :destroy]
   end
 
   get '/become/:id', to: 'admin#become'

--- a/db/migrate/20150724031812_add_status_enum_to_invitations.rb
+++ b/db/migrate/20150724031812_add_status_enum_to_invitations.rb
@@ -1,0 +1,5 @@
+class AddStatusEnumToInvitations < ActiveRecord::Migration
+  def change
+    add_column :invitations, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150723224707) do
+ActiveRecord::Schema.define(version: 20150724031812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,8 +53,9 @@ ActiveRecord::Schema.define(version: 20150723224707) do
     t.string   "recipient_email"
     t.string   "token"
     t.datetime "sent_at"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.integer  "status",          default: 0
   end
 
   create_table "notifications", force: :cascade do |t|


### PR DESCRIPTION
This gives admins the ability to create, revoke, and view pending, claimed, and waitlisted invites. Closes #44 and closes #47 
