### PR TITLE
Add track location rake task and update admin screens

### DIFF
--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -1,13 +1,17 @@
 class Admin::TracksController < AdminController
-  
+
   def index
     @tracks = Track.all
   end
-  
+
   def new
     @track = Track.new
   end
-  
+
+  def edit
+    @track = Track.find(params[:id])
+  end
+
   def create
     @track = Track.new(track_params)
     if @track.save
@@ -17,11 +21,20 @@ class Admin::TracksController < AdminController
       render 'new'
     end
   end
-  
+
+  def update
+    @track = Track.find(params[:id])
+    if @track.update_attributes(track_params)
+      redirect_to admin_tracks_path, success: 'Track updated'
+    else
+      render 'edit'
+    end
+  end
+
   private
-  
+
   def track_params
-    params.require(:track).permit(:name)
+    params.require(:track).permit(:name, :latitude, :longitude)
   end
 
 end

--- a/app/controllers/timesheets_controller.rb
+++ b/app/controllers/timesheets_controller.rb
@@ -19,7 +19,7 @@ class TimesheetsController < ApplicationController
     @timesheet = Timesheet.find(params[:id])
     @ranked = @timesheet.ranked_entries
     @best = @timesheet.best_runs
-    @runs = @timesheet.ranked_runs
+    @runs = @timesheet.ranked_runs if @ranked.present?
     respond_to do |format|
       format.html do
         if current_user

--- a/app/views/admin/tracks/_form.html.erb
+++ b/app/views/admin/tracks/_form.html.erb
@@ -1,0 +1,16 @@
+<%= form_for [:admin, @track] do |f| %>
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :latitude %>
+    <%= f.text_field :latitude, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :longitude %>
+    <%= f.text_field :longitude, class: 'form-control' %>
+  </div>
+  <%= f.submit %>
+
+<% end %>

--- a/app/views/admin/tracks/edit.html.erb
+++ b/app/views/admin/tracks/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit Track</h1>
+
+<%= render 'form' %>

--- a/app/views/admin/tracks/index.html.erb
+++ b/app/views/admin/tracks/index.html.erb
@@ -1,0 +1,6 @@
+<h1>Tracks</h1>
+<ul>
+  <% @tracks.each do |track| %>
+    <li><%= link_to track.name, edit_admin_track_path(track) %></li>
+  <% end %>
+</ul>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,24 +21,24 @@ end
 
 if Track.count == 0
   tracks = Track.create([
-    { name: 'Altenberg' },
-    { name: 'Calgary' },
-    { name: 'Cesana' },
-    { name: 'Cortina' },
-    { name: 'Igls' },
-    { name: 'Konigssee' },
-    { name: 'La Plagne' },
-    { name: 'Lake Placid' },
-    { name: 'Lillehammer' },
-    { name: 'Nagano' },
-    { name: 'Oberhof' },
-    { name: 'Paramanovo' },
-    { name: 'Park City' },
-    { name: 'Sigulda' },
-    { name: 'Sochi' },
-    { name: 'St. Moritz' },
-    { name: 'Whistler' },
-    { name: 'Winterberg' }
+    { name: 'Altenberg', latitude: 50.782300, longitude: 13.723007 },
+    { name: 'Calgary', latitude: 51.076713, longitude: -114.221485 },
+    { name: 'Cesana', latitude: 44.952524, longitude: 6.816209 },
+    { name: 'Cortina', latitude: 46.545701, longitude: 12.127775 },
+    { name: 'Igls', latitude: 47.221125, longitude: 11.435487 },
+    { name: 'Konigssee', latitude: 47.590213, longitude: 12.976009 },
+    { name: 'La Plagne', latitude: 45.519972, longitude: 6.680548 },
+    { name: 'Lake Placid', latitude: 44.213196, longitude: -73.924767},
+    { name: 'Lillehammer', latitude: 61.220615, longitude: 10.419124 },
+    { name: 'Nagano', latitude: 36.710858, longitude: 138.157331 },
+    { name: 'Oberhof', latitude: 50.708923, longitude: 10.707584 },
+    { name: 'Paramanovo', latitude: 56.244244, longitude: 37.446495},
+    { name: 'Park City', latitude: 40.705174, longitude: -111.563905 },
+    { name: 'Sigulda', latitude: 57.151264, longitude: 24.840675 },
+    { name: 'Sochi', latitude: 43.662831, longitude: 40.288486 },
+    { name: 'St. Moritz', latitude: 46.501569, longitude: 9.847278},
+    { name: 'Whistler', latitude: 50.106908, longitude: -122.944761 },
+    { name: 'Winterberg', latitude: 51.182209, longitude: 8.508864}
   ])
 end
 

--- a/lib/tasks/tracks.rake
+++ b/lib/tasks/tracks.rake
@@ -1,0 +1,50 @@
+namespace :tracks do
+  desc 'add latitude and longitude to tracks'
+  task set_location: :environment do
+    puts "Update track location..."
+    Track.all.each do |track|
+      case track.name
+      when "Altenberg"
+        track.update(latitude: 50.782300, longitude: 13.723007 )
+      when 'Calgary'
+        track.update(latitude: 44.952524, longitude: 6.816209)
+      when 'Cesana'
+        track.update(latitude: 44.952524, longitude: 6.816209)
+      when 'Cortina'
+        track.update(latitude: 46.545701, longitude: 12.127775)
+      when 'Igls'
+        track.update(latitude: 47.221125, longitude: 11.435487)
+      when 'Konigssee'
+        track.update(latitude: 47.590213, longitude: 12.976009)
+      when 'Konigssee (old)'
+        track.update(latitude: 47.590213, longitude: 12.976009)
+      when 'La Plagne'
+        track.update(latitude: 45.519972, longitude: 6.680548)
+      when 'Lake Placid'
+        track.update(latitude: 44.213196, longitude: -73.924767)
+      when 'Lillehammer'
+        track.update(latitude: 61.220615, longitude: 10.419124)
+      when 'Nagano'
+        track.update(latitude: 36.710858, longitude: 138.157331)
+      when 'Oberhof'
+        track.update(latitude: 50.708923, longitude: 10.707584)
+      when 'Paramanovo'
+        track.update(latitude: 56.244244, longitude: 37.446495)
+      when 'Park City'
+        track.update(latitude: 40.705174, longitude: -111.563905)
+      when 'Sigulda'
+        track.update(latitude: 57.151264, longitude: 24.840675)
+      when 'Sochi'
+        track.update(latitude: 43.662831, longitude: 40.288486)
+      when 'St. Moritz'
+        track.update(latitude: 46.501569, longitude: 9.847278)
+      when 'Whistler'
+        track.update(latitude: 50.106908, longitude: -122.944761)
+      when 'Winterberg'
+        track.update(latitude: 51.182209, longitude: 8.508864)
+      end
+      puts "."
+      track.save
+    end
+  end
+end


### PR DESCRIPTION
This PR creates a rake task for updating track locations. It updates the seed file for tracks (for future installs such as bobsled or luge) and creates administrative screens for editing them. 
