### PR TITLE
Shared timesheets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development do
   gem 'bullet'
   gem 'web-console'
   gem 'listen', '~> 3.0.5'
+  gem "letter_opener"
   #gem 'rack-mini-profiler'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       sass (~> 3.2)
     buftok (0.2.0)
     builder (3.2.2)
-    bullet (5.3.0)
+    bullet (5.4.3)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
     byebug (9.0.0)
@@ -90,7 +90,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.3)
     connection_pool (2.2.0)
     countries (1.2.5)
       currencies (~> 0.4.2)
@@ -186,7 +186,7 @@ GEM
     mimemagic (0.3.2)
     mini_magick (4.5.1)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.10.1)
     minitest-reporters (1.1.9)
       ansi
       builder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,10 @@ GEM
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -371,6 +375,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   kaminari
+  letter_opener
   listen (~> 3.0.5)
   mini_magick
   minitest-reporters (= 1.1.9)

--- a/app/assets/javascripts/users.js.coffee
+++ b/app/assets/javascripts/users.js.coffee
@@ -1,3 +1,4 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/
+$(document).on "turbolinks:load", ->
+  $('body').on 'shown.bs.modal', '.share-timesheet-modal', (e) ->
+    timesheet_id = $(e.relatedTarget).data('timesheet-id')
+    $('#timesheet_id').val timesheet_id

--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -1,6 +1,12 @@
 class RunsController < ApplicationController
   before_action :load_entry_and_timesheet, except: [:edit, :update, :destroy]
-  before_action :admin_user, only: [:new, :edit, :create, :destroy]
+  # before_action :admin_user, only: [:new, :edit, :create, :destroy]
+  before_action :authorize_user
+
+  # if you are an admin, you can add a run
+  # if this is your timesheet, you can add a run
+  # if you have sharing permission (admin level) you can add a run.
+  # else redirect
 
   def new
     @run = @entry.runs.new
@@ -51,5 +57,15 @@ class RunsController < ApplicationController
     def load_entry_and_timesheet
       @entry = Entry.find(params[:entry_id])
       @timesheet = @entry.timesheet
+    end
+
+    def authorize_user
+      if current_user
+        unless @timesheet.user == current_user || current_user.admin?# || current_user.has_share_access?(@timesheet)
+          redirect_to timesheet_path(@timesheet), alert: "Sorry, you don't have permission to do that."
+        end
+      else
+        redirect_to timesheet_path(@timesheet), alert: "Sorry, you don't have permissino to do that."
+      end
     end
 end

--- a/app/controllers/timesheets_controller.rb
+++ b/app/controllers/timesheets_controller.rb
@@ -98,6 +98,7 @@ class TimesheetsController < ApplicationController
   end
 
   def share
+    @timesheet = Timesheet.find(params[:id])
     email_addresses = params[:emails].split(",")
     email_addresses.each do |email|
       @shared_timesheet = current_user.shared_timesheets.new
@@ -107,9 +108,14 @@ class TimesheetsController < ApplicationController
       shared_user = User.find_by(email: email)
       @shared_timesheet.shared_user_id = shared_user.id if shared_user
       @shared_timesheet.message = params[:message]
-      @shared_timesheet.save
 
-      UserMailer.invitation_to_share(@shared_timesheet).deliver # move to background
+      respond_to do |format|
+        format.js {
+          if @shared_timesheet.save
+            UserMailer.invitation_to_share(@shared_timesheet).deliver
+          end
+        }
+      end
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,8 +12,10 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = User.find(params[:id]) # shouldn't this be current user?
     @timesheets = @user.timesheets.includes(:track).personal
+    # timesheets shared by others
+    @being_shared_timesheets = current_user.shared_timesheets_by_others 
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,9 @@ class UsersController < ApplicationController
     @user = User.find(params[:id]) # shouldn't this be current user?
     @timesheets = @user.timesheets.includes(:track).personal
     # timesheets shared by others
-    @being_shared_timesheets = current_user.shared_timesheets_by_others 
+    @being_shared_timesheets = current_user.shared_timesheets_by_others # N+1 queries
+
+    #@being_shared_timesheets = current_user.being_shared_timesheets.includes(:timesheet)
   end
 
   def create

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -16,4 +16,10 @@ class UserMailer < ApplicationMailer
     mail to: user.email, subject: "Sledsheet password reset"
   end
 
+  def invitation_to_share(shared_timesheet)
+    @shared_timesheet = shared_timesheet
+    mail to: @shared_timesheet.shared_email,
+         subject: "#{@shared_timesheet.user.name} wants to share the  #{@shared_timesheet.timesheet.name} timesheet with you"
+  end
+
 end

--- a/app/models/shared_timesheet.rb
+++ b/app/models/shared_timesheet.rb
@@ -1,0 +1,5 @@
+class SharedTimesheet < ApplicationRecord
+  belongs_to :user
+  belongs_to :shared_user, class_name: "User", foreign_key: "shared_user_id"
+  belongs_to :timesheet 
+end

--- a/app/models/shared_timesheet.rb
+++ b/app/models/shared_timesheet.rb
@@ -3,5 +3,6 @@ class SharedTimesheet < ApplicationRecord
   belongs_to :shared_user, class_name: "User", foreign_key: "shared_user_id"
   belongs_to :timesheet
 
-  validates :user_id, :timesheet_id, :shared_email, presence: true 
+  validates :user_id, :timesheet_id, :shared_email, presence: true
+  validates :shared_user_id, uniqueness: { scope: :timesheet_id }, allow_blank: true
 end

--- a/app/models/shared_timesheet.rb
+++ b/app/models/shared_timesheet.rb
@@ -1,5 +1,7 @@
 class SharedTimesheet < ApplicationRecord
   belongs_to :user
   belongs_to :shared_user, class_name: "User", foreign_key: "shared_user_id"
-  belongs_to :timesheet 
+  belongs_to :timesheet
+
+  validates :user_id, :timesheet_id, :shared_email, presence: true 
 end

--- a/app/models/timesheet.rb
+++ b/app/models/timesheet.rb
@@ -19,6 +19,7 @@ class Timesheet < ActiveRecord::Base
   has_many :runs, through: :heats
   has_many :runs, through: :entries # :heats, eventually? maybe doesn't matter
   has_many :points, dependent: :destroy
+  has_many :shared_timesheets, dependent: :destroy
 
   validates :name, presence: true
   validates :date, presence: true
@@ -115,6 +116,10 @@ class Timesheet < ActiveRecord::Base
 
   def points_eligible
     race? && complete?
+  end
+
+  def shared?
+    !self.shared_timesheets.empty?
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,8 +18,10 @@ class User < ActiveRecord::Base
   has_many :timesheets
   has_one :athlete
   has_many :shared_timesheets, dependent: :destroy
-  has_many :being_shared_timesheets, class_name: "SharedTimesheet", foreign_key: "shared_user_id", dependent: :destroy
-  has_many :shared_timesheets_by_others, through: :being_shared_timesheets, source: :timesheet # returns actual timesheet records 
+
+  has_many :being_shared_timesheets, class_name: "SharedTimesheet", foreign_key: "shared_user_id", dependent: :destroy # returns SharedTimesheet records
+
+  has_many :shared_timesheets_by_others, through: :being_shared_timesheets, source: :timesheet # returns actual timesheet records. source of N+1?
 
   def self.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost

--- a/app/views/timesheets/share.js.erb
+++ b/app/views/timesheets/share.js.erb
@@ -1,0 +1,3 @@
+$('.share-timesheet-modal').modal('toggle');
+$("#flash_notice").remove();
+$(".timesheet-container").prepend("<div class='alert alert-success'>The timesheet has been shared.</div>");

--- a/app/views/timesheets/show.html.erb
+++ b/app/views/timesheets/show.html.erb
@@ -15,6 +15,7 @@
 <%= link_to "Generate PDF", timesheet_path(@timesheet, format: "pdf") %>
 
 
+
 <% if @timesheet.entries.blank? %>
   <p>There are no entries yet</p>
 <% else %>

--- a/app/views/timesheets/show_advanced.html.erb
+++ b/app/views/timesheets/show_advanced.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, @timesheet.name) %>
 
 <section class="timesheet-header">
-  <div class="container">
+  <div class="container timesheet-container">
     <header>
       <div class="timesheet-title">
         <h2><%= @timesheet.name %></h2>
@@ -47,9 +47,9 @@
             <li role="presentation" class="divider"></li>
             <li role="presentation" class="dropdown-header">SHARING</li>
             <% if @timesheet.user == current_user %>
-              
 
-              <li role="presentation"><%= link_to "Share timesheet", "#",data: {toggle: "modal", target: ".share-timesheet-modal", timesheet_id: @timesheet.id}, role: 'menuitem', tabindex: -1 %></li>
+
+              <li role="presentation"><%= link_to "Share timesheet", "#", data: {toggle: "modal", target: ".share-timesheet-modal", timesheet_id: @timesheet.id}, role: 'menuitem', tabindex: -1 %></li>
 
             <% elsif @is_this_timesheet_being_shared %>
               <li role="presentation"><%= link_to "Leave timesheet", leave_sharing_timesheet_path(@timesheet), role: 'menuitem', tabindex: -1 %></li>
@@ -111,6 +111,6 @@
   </div>
 </div>
 
-<%= render 'users/share_modal' %>
-
 <% end %>
+
+<%= render 'users/share_modal' %>

--- a/app/views/timesheets/show_advanced.html.erb
+++ b/app/views/timesheets/show_advanced.html.erb
@@ -38,8 +38,22 @@
         <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1">
 
           <% if @timesheet.personal? %>
-            <li role="presentation"><%= link_to 'Edit Timesheet', edit_timesheet_path(@timesheet), role: 'menuitem', tabindex: -1 %>
             <li role="presentation"><%= link_to "Generate PDF", timesheet_path(@timesheet, format: "pdf", role: "menuitem", tabindex: -1) %>
+            <% if @timesheet.user == current_user %>
+              <li role="presentation"><%= link_to 'Edit Timesheet', edit_timesheet_path(@timesheet), role: 'menuitem', tabindex: -1 %>
+              <li role="presentation"><%= link_to 'Copy Timesheet', copy_timesheet_path(@timesheet), role: 'menuitem', tabindex: -1 %></li>
+              <li role="presentation"><%= link_to "Delete timesheet", @timesheet, method: :delete, data: { confirm: "You sure?" }, role: 'menuitem', tabindex: -1 %></li>
+            <% end %>
+            <li role="presentation" class="divider"></li>
+            <li role="presentation" class="dropdown-header">SHARING</li>
+            <% if @timesheet.user == current_user %>
+              
+
+              <li role="presentation"><%= link_to "Share timesheet", "#",data: {toggle: "modal", target: ".share-timesheet-modal", timesheet_id: @timesheet.id}, role: 'menuitem', tabindex: -1 %></li>
+
+            <% elsif @is_this_timesheet_being_shared %>
+              <li role="presentation"><%= link_to "Leave timesheet", leave_sharing_timesheet_path(@timesheet), role: 'menuitem', tabindex: -1 %></li>
+            <% end %>
           <% end %>
 
           <% if @timesheet.general? %>
@@ -55,10 +69,6 @@
             <li role="presentation"><%= link_to 'Copy Timesheet', copy_timesheet_path(@timesheet), role: 'menuitem', tabindex: -1 %></li>
             <li role="presentation"><%= link_to "Delete timesheet", @timesheet, method: :delete, data: { confirm: "You sure?" }, role: 'menuitem', tabindex: -1 %></li>
           <% end %>
-
-          <li role="presentation" class="divider"></li>
-          <li role="presentation" class="dropdown-header">SHARING</li>
-          <li role="presentation"><%= link_to "Share timesheet", "#",data: {toggle: "modal", target: ".share-timesheet-modal", timesheet_id: @timesheet.id}, role: 'menuitem', tabindex: -1 %></li>
 
         </ul>
       </div>

--- a/app/views/timesheets/show_advanced.html.erb
+++ b/app/views/timesheets/show_advanced.html.erb
@@ -55,6 +55,11 @@
             <li role="presentation"><%= link_to 'Copy Timesheet', copy_timesheet_path(@timesheet), role: 'menuitem', tabindex: -1 %></li>
             <li role="presentation"><%= link_to "Delete timesheet", @timesheet, method: :delete, data: { confirm: "You sure?" }, role: 'menuitem', tabindex: -1 %></li>
           <% end %>
+
+          <li role="presentation" class="divider"></li>
+          <li role="presentation" class="dropdown-header">SHARING</li>
+          <li role="presentation"><%= link_to "Share timesheet", "#",data: {toggle: "modal", target: ".share-timesheet-modal", timesheet_id: @timesheet.id}, role: 'menuitem', tabindex: -1 %></li>
+
         </ul>
       </div>
     </header>
@@ -96,5 +101,6 @@
   </div>
 </div>
 
+<%= render 'users/share_modal' %>
 
 <% end %>

--- a/app/views/user_mailer/invitation_to_share.text.erb
+++ b/app/views/user_mailer/invitation_to_share.text.erb
@@ -1,0 +1,12 @@
+Hi,
+
+<%= @shared_timesheet.user.name %> has shared the <%= @shared_timesheet.timesheet.name %> timesheet with you on Sledsheet.
+
+Message from <%= @shared_timesheet.user.name %>:
+<%= @shared_timesheet.message %>
+
+You can login and view the timesheet if you have an account already. If you don't have one, you can sign up here.
+
+Happy sliding,
+
+Sledsheet 

--- a/app/views/user_mailer/invitation_to_share.text.erb
+++ b/app/views/user_mailer/invitation_to_share.text.erb
@@ -2,11 +2,13 @@ Hi,
 
 <%= @shared_timesheet.user.name %> has shared the <%= @shared_timesheet.timesheet.name %> timesheet with you on Sledsheet.
 
-Message from <%= @shared_timesheet.user.name %>:
-<%= @shared_timesheet.message %>
+<% if @shared_timesheet.message.present? %>
+  Message from <%= @shared_timesheet.user.name %>:
+  <%= @shared_timesheet.message %>
+<% end %>
 
 You can login and view the timesheet if you have an account already. If you don't have one, you can sign up here.
 
 Happy sliding,
 
-Sledsheet 
+Sledsheet

--- a/app/views/users/_share_modal.html.erb
+++ b/app/views/users/_share_modal.html.erb
@@ -15,6 +15,10 @@
           <%= label_tag :message, 'Message (optional)' %>
           <%= text_area_tag :message, nil, class: 'form-control' %>
         </div>
+        <div class="form-group">
+          <%= label_tag :admin, "allow editing?" %>
+          <%= check_box_tag("admin", "value", false, class: "checkbox") %>
+        </div>
           <%= hidden_field_tag :timesheet_id %>
           <%= submit_tag 'Share', class: 'btn btn-primary' %>
         <% end %>

--- a/app/views/users/_share_modal.html.erb
+++ b/app/views/users/_share_modal.html.erb
@@ -6,7 +6,8 @@
         <h4 class="modal-title" id="myModalLabel">Share this timesheet</h4>
       </div>
       <div class="modal-body">
-        <%= form_tag share_timesheet_path do %>
+        <%= form_tag share_timesheet_path, remote: true, format: :js do %>
+        <% # errors %>
         <div class="form-group">
           <%= label_tag :emails, "Enter recipient emails, seperated by commas" %>
           <%= text_field_tag :emails, nil, class: 'form-control' %>

--- a/app/views/users/_share_modal.html.erb
+++ b/app/views/users/_share_modal.html.erb
@@ -1,0 +1,24 @@
+<div class="modal fade share-timesheet-modal" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="myModalLabel">Share this timesheet</h4>
+      </div>
+      <div class="modal-body">
+        <%= form_tag share_timesheet_path do %>
+        <div class="form-group">
+          <%= label_tag :emails, "Enter recipient emails, seperated by commas" %>
+          <%= text_field_tag :emails, nil, class: 'form-control' %>
+        </div>
+        <div class="form-group">
+          <%= label_tag :message, 'Message (optional)' %>
+          <%= text_area_tag :message, nil, class: 'form-control' %>
+        </div>
+          <%= hidden_field_tag :timesheet_id %>
+          <%= submit_tag 'Share', class: 'btn btn-primary' %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/share.js.erb
+++ b/app/views/users/share.js.erb
@@ -1,0 +1,3 @@
+$('.share-timesheet-modal').dialog("close");
+$("#flash_notice").remove();
+#(".container").prepend("<div id='flash_notice'>Shared</div>");

--- a/app/views/users/share.js.erb
+++ b/app/views/users/share.js.erb
@@ -1,3 +1,0 @@
-$('.share-timesheet-modal').dialog("close");
-$("#flash_notice").remove();
-#(".container").prepend("<div id='flash_notice'>Shared</div>");

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,7 +39,7 @@
     <tr>
       <td><%= link_to timesheet.name, timesheet_url(timesheet) %></td>
       <td><%= track_time timesheet %></td>
-      <td>Not sure yet</td>
+      <td><%= timesheet.user.name %></td>
     </tr>
     <% end %>
   </table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,7 +24,11 @@
     <tr>
       <td><%= link_to timesheet.name, timesheet_url(timesheet) %></td>
       <td><%= track_time timesheet %></td>
-      <td><%= link_to 'Share', '#', data: {toggle: "modal", target: ".share-timesheet-modal", timesheet_id: timesheet.id} %></td>
+      <td>
+        <%= link_to '#', data: {toggle: "modal", target: ".share-timesheet-modal", timesheet_id: timesheet.id} , class: 'text-muted' do %>
+          <%= fa_icon 'share-square-o', text: 'share' %>
+        <% end %>
+      </td>
     </tr>
     <% end %>
   </table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,12 +18,31 @@
     <tr>
       <th>Name</th>
       <th>Date</th>
+      <th>Actions</th>
     </tr>
     <% @timesheets.each do |timesheet| %>
     <tr>
       <td><%= link_to timesheet.name, timesheet_url(timesheet) %></td>
       <td><%= track_time timesheet %></td>
+      <td><%= link_to 'Share', '#', data: {toggle: "modal", target: ".share-timesheet-modal", timesheet_id: timesheet.id} %></td>
+    </tr>
+    <% end %>
+  </table>
+  <h3>Shared</h3>
+  <table class="table">
+    <tr>
+      <th>Name</th>
+      <th>Date</th>
+      <th>Shared By</th>
+    </tr>
+    <% @being_shared_timesheets.each do |timesheet| %>
+    <tr>
+      <td><%= link_to timesheet.name, timesheet_url(timesheet) %></td>
+      <td><%= track_time timesheet %></td>
+      <td>Not sure yet</td>
     </tr>
     <% end %>
   </table>
 </div>
+
+<%= render 'share_modal' %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,6 +31,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.delivery_method = :letter_opener
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,4 +1,5 @@
 if defined? Bullet
   Bullet.enable = true
-  Bullet.alert = true
+  # Bullet.alert = true
+  Bullet.console = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,8 @@ Rails.application.routes.draw do
   resources :timesheets do
     post 'import', on: :member
     get 'copy', on: :member
-    post 'share', on: :member 
+    post 'share', on: :member
+    get 'leave_sharing', on: :member
 
     resources :entries, shallow: true do
       collection { post :sort }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   resources :timesheets do
     post 'import', on: :member
     get 'copy', on: :member
+    post 'share', on: :member 
 
     resources :entries, shallow: true do
       collection { post :sort }

--- a/db/migrate/20161220214427_create_shared_timesheets.rb
+++ b/db/migrate/20161220214427_create_shared_timesheets.rb
@@ -1,0 +1,17 @@
+class CreateSharedTimesheets < ActiveRecord::Migration[5.0]
+  def change
+    create_table :shared_timesheets do |t|
+      t.integer :user_id
+      t.string :shared_email
+      t.integer :shared_user_id
+      t.integer :timesheet_id
+      t.string :message
+
+      t.timestamps
+    end
+
+    add_index :shared_timesheets, :user_id
+    add_index :shared_timesheets, :shared_user_id
+    add_index :shared_timesheets, :timesheet_id 
+  end
+end

--- a/db/migrate/20161222002017_add_index_to_shared_timesheets.rb
+++ b/db/migrate/20161222002017_add_index_to_shared_timesheets.rb
@@ -1,0 +1,5 @@
+class AddIndexToSharedTimesheets < ActiveRecord::Migration[5.0]
+  def change
+    add_index :shared_timesheets, [:timesheet_id, :shared_user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161220214427) do
+ActiveRecord::Schema.define(version: 20161222002017) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,6 +148,7 @@ ActiveRecord::Schema.define(version: 20161220214427) do
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.index ["shared_user_id"], name: "index_shared_timesheets_on_shared_user_id", using: :btree
+    t.index ["timesheet_id", "shared_user_id"], name: "index_shared_timesheets_on_timesheet_id_and_shared_user_id", unique: true, using: :btree
     t.index ["timesheet_id"], name: "index_shared_timesheets_on_timesheet_id", using: :btree
     t.index ["user_id"], name: "index_shared_timesheets_on_user_id", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160812044459) do
+ActiveRecord::Schema.define(version: 20161220214427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -137,6 +137,19 @@ ActiveRecord::Schema.define(version: 20160812044459) do
     t.date     "end_date"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "shared_timesheets", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "shared_email"
+    t.integer  "shared_user_id"
+    t.integer  "timesheet_id"
+    t.string   "message"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.index ["shared_user_id"], name: "index_shared_timesheets_on_shared_user_id", using: :btree
+    t.index ["timesheet_id"], name: "index_shared_timesheets_on_timesheet_id", using: :btree
+    t.index ["user_id"], name: "index_shared_timesheets_on_user_id", using: :btree
   end
 
   create_table "teams", force: :cascade do |t|

--- a/test/fixtures/shared_timesheets.yml
+++ b/test/fixtures/shared_timesheets.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  shared_email: MyString
+  shared_user_id: 1
+  timesheet_id: 1
+  message: MyString
+
+two:
+  user_id: 1
+  shared_email: MyString
+  shared_user_id: 1
+  timesheet_id: 1
+  message: MyString

--- a/test/models/shared_timesheet_test.rb
+++ b/test/models/shared_timesheet_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SharedTimesheetTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This PR allows users to share their private timesheets with other users (whether they have an account or not). TODO:

- [x] Ensure the sharing form is submitted via AJAX and dismissed after successful submission. 
- [ ] Allow basic management of sharing (stop sharing, leave shared timesheet). 
- [x] Prevent sharing the same timesheet with the same user twice. 
- [ ] Add form errors (might need to convert form_tag to form_for `@shared_timesheet`)
- [ ] Allow granular privileges (read only, read+write). 
- [ ] Sync new user accounts with potential existing shared timesheets. 

This PR also fixes a bug where non-admin users could not create runs on their own timesheets. 