### PR TITLE
Convert Timesheets to single table inheritance 

### DIFF
--- a/app.json
+++ b/app.json
@@ -50,7 +50,7 @@
   },
   "addons": [
     "heroku-postgresql",
-    "papertrail"
+    "heroku-redis"
   ],
   "buildpacks": [
     {

--- a/app/controllers/admin/timesheet_imports_controller.rb
+++ b/app/controllers/admin/timesheet_imports_controller.rb
@@ -1,0 +1,10 @@
+class Admin::TimesheetImportsController < AdminController
+
+  def new
+  end
+
+  def create
+    ImportTimesheetJob.perform_later(params[:url], params[:finish_td])
+    redirect_to timesheets_path, success: "Your import has started. We'll notify you when it's complete"
+  end
+end

--- a/app/controllers/admin/timesheets_controller.rb
+++ b/app/controllers/admin/timesheets_controller.rb
@@ -1,0 +1,44 @@
+class Admin::TimesheetsController < AdminController
+
+  before_action :load_timesheet, only: [:edit, :update]
+
+  def index
+    @timesheets = PublicTimesheet.all.includes(:season, :track)
+  end
+
+  def new
+    @timesheet = PublicTimesheet.new
+  end
+
+  def edit
+  end
+
+  def update
+    if @timesheet.update_attributes(timesheet_params)
+      redirect_to admin_timesheets_path, success: 'Timesheet updated.'
+    else
+      render 'edit'
+    end
+  end
+
+  def create
+    @timesheet = PublicTimesheet.new(timesheet_params)
+    if @timesheet.save
+      flash[:success] = "Timesheet created."
+      redirect_to @timesheet
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+  def timesheet_params
+    params.require(:timesheet).permit(:name, :time_zone, :latitude, :longitude)
+  end
+
+  def load_Timesheet
+    @timesheet = Timesheet.friendly.find(params[:id])
+  end
+
+end

--- a/app/controllers/admin/timesheets_controller.rb
+++ b/app/controllers/admin/timesheets_controller.rb
@@ -1,9 +1,10 @@
 class Admin::TimesheetsController < AdminController
 
   before_action :load_timesheet, only: [:edit, :update]
+  before_action :set_track_time_zone, only: [:create, :update]
+  before_action :set_track_time_zone_edit, only: [:edit]
 
   def index
-    @timesheets = PublicTimesheet.all.includes(:season, :track)
   end
 
   def new
@@ -23,6 +24,7 @@ class Admin::TimesheetsController < AdminController
 
   def create
     @timesheet = PublicTimesheet.new(timesheet_params)
+    @timesheet.user = current_user
     if @timesheet.save
       flash[:success] = "Timesheet created."
       redirect_to @timesheet
@@ -34,7 +36,25 @@ class Admin::TimesheetsController < AdminController
   private
 
   def timesheet_params
-    params.require(:timesheet).permit(:name, :time_zone, :latitude, :longitude)
+    params.require(:timesheet).permit(:name, :nickname, :track_id, :circuit_id, :date, :race, :season_id, :pdf, :gender, :remote_pdf_url, :remove_pdf, :tweet, :status, :user_id)
+  end
+
+  def set_track_time_zone
+    if params[:timesheet][:track_id]
+      track = Track.find(params[:timesheet][:track_id])
+      Time.zone = track.time_zone
+    end
+  end
+
+  def set_track_time_zone_edit
+    Time.zone = @timesheet.track.time_zone
+  end
+
+  def award_points
+    @timesheet = Timesheet.friendly.find(params[:id])
+    if @timesheet.race && @timesheet.complete
+      @timesheet.award_points
+    end
   end
 
   def load_Timesheet

--- a/app/controllers/api/v1/circuits_controller.rb
+++ b/app/controllers/api/v1/circuits_controller.rb
@@ -6,9 +6,10 @@ class Api::V1::CircuitsController < ApplicationController
   def show
     @circuit = Circuit.find(params[:id])
     if params[:gender] == 'men'
-      @rankings = @circuit.current_rankings(0)
+      # @rankings = @circuit.current_rankings(0)
     elsif params[:gender] == 'women'
-      @rankings = @circuit.current_rankings(1)
+      # @rankings = @circuit.current_rankings(1)
+      # see circuit_points for update? 
     end
   end
 

--- a/app/controllers/athletes_controller.rb
+++ b/app/controllers/athletes_controller.rb
@@ -11,7 +11,7 @@ class AthletesController < ApplicationController
     @season = Season.current_season
     @points = @athlete.season_positions(@season)
     @total_points = @points[0..7].map { |h| h[:value] }.sum
-    @races = @athlete.timesheets.includes(:track).general.where(race: true)
+    @races = @athlete.timesheets.includes(:track).where(race: true)
     render layout: "athlete"
   end
 

--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -50,7 +50,7 @@ class RunsController < ApplicationController
     end
 
     def load_entry_and_timesheet
-      @entry = Entry.find(params[:entry_id])
+      @entry = Entry.includes(:timesheet).find(params[:entry_id])
       @timesheet = @entry.timesheet
     end
 
@@ -59,7 +59,7 @@ class RunsController < ApplicationController
     end
 
     def correct_user
-      @user = @run.entry.timesheet.user
+      @user = @timesheet.user
       redirect_to(root_url) unless current_user?(@user)
     end
 end

--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -1,6 +1,6 @@
 class RunsController < ApplicationController
   before_action :load_entry_and_timesheet, except: [:edit, :update, :destroy]
-  before_action :admin_user, only: [:new, :edit, :create, :destroy]
+  before_action :correct_user, only: [:new, :edit, :create, :destroy]
 
   def new
     @run = @entry.runs.new
@@ -51,5 +51,10 @@ class RunsController < ApplicationController
     def load_entry_and_timesheet
       @entry = Entry.find(params[:entry_id])
       @timesheet = @entry.timesheet
+    end
+
+    def correct_user
+      @user = @timesheet.user
+      redirect_to(root_url) unless current_user?(@user)
     end
 end

--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -1,5 +1,6 @@
 class RunsController < ApplicationController
   before_action :load_entry_and_timesheet, except: [:edit, :update, :destroy]
+  before_action :load_run, only: [:edit]
   before_action :correct_user, only: [:new, :edit, :create, :destroy]
 
   def new
@@ -53,8 +54,12 @@ class RunsController < ApplicationController
       @timesheet = @entry.timesheet
     end
 
+    def load_run
+      @run = Run.find(params[:id])
+    end
+
     def correct_user
-      @user = @timesheet.user
+      @user = @run.entry.timesheet.user
       redirect_to(root_url) unless current_user?(@user)
     end
 end

--- a/app/controllers/timesheets_controller.rb
+++ b/app/controllers/timesheets_controller.rb
@@ -1,14 +1,14 @@
 class TimesheetsController < ApplicationController
   before_action :logged_in_user, except: [:index, :show]
   before_action :correct_user, if: :personal_timesheet?, only: [:update, :edit, :destroy, :show]
-  before_action :admin_user, if: :general_timesheet?, only: [:update, :edit, :destroy]
+
 
   before_action :set_track_time_zone, only: [:create, :update]
   before_action :set_track_time_zone_edit, only: [:edit]
   before_action :load_timesheet, only: [:copy,:show,:edit,:update,:destroy]
 
   def index
-    @timesheets = Timesheet.general.includes(:season, :track).filter(filtering_params).page params[:page]
+    @timesheets = PublicTimesheet.all.includes(:season, :track).filter(filtering_params).page params[:page]
   end
 
   def new
@@ -46,14 +46,14 @@ class TimesheetsController < ApplicationController
       end
       award_points
       flash[:success] = "Timesheet updated."
-      redirect_to @timesheet
+      redirect_to timesheet_path(@timesheet) # error here.
     else
       render 'edit'
     end
   end
 
   def create
-    @timesheet = current_user.timesheets.build(timesheet_params)
+    @timesheet = current_user.private_timesheets.build(timesheet_params)
 
     if @timesheet.save
       # Notification.create(recipient: current_user, actor: current_user, action: "posted", notifiable: @timesheet)
@@ -78,74 +78,6 @@ class TimesheetsController < ApplicationController
     @visibilities = Timesheet.visibilities
     @timesheet = Timesheet.new(@timesheet.attributes)
     render :new
-  end
-
-  def import
-    require 'nokogiri'
-    require 'open-uri'
-    def time_to_integer(time_str)
-      if /[:]/ =~ time_str
-        minutes, seconds, centiseconds = time_str.split(/[:.]/).map{|str| str.to_i}
-        (minutes * 60 + seconds) * 100 + centiseconds
-      else
-        time_str.delete('.').to_i
-      end
-    rescue
-      99999 # make it absurdly high to prevent ranking errors
-    end
-    @timesheet = Timesheet.friendly.find(params[:id])
-    url = params[:url]
-    page = Nokogiri::HTML(open(url))
-    page.css(".table")
-    trs = page.css('.crew, .run').to_a
-    entries = trs.slice_before{ |elm| elm.attr('class') =='crew' }.to_a
-
-    entries.map! do |entry|
-      {
-        name: entry.at(0).css("td.visible-xs div.fl.athletes a").text.strip,
-        country: entry.at(0).css("div.fl.athletes img.country-flag").attr('alt').text,
-        runs: entry.select{ |tr| tr.attr('class') == 'run' }.map do |run|
-          {
-            start: run.css('td')[1].text.strip,
-            split2: run.css('td')[2].text.strip,
-            split3: run.css('td')[3].text.strip,
-            split4: run.css('td')[4].text.strip,
-            split5: run.css('td')[5].text.strip,
-            finish: run.css('td')[6].text[/([0-1]:[0-5][0-9].[0-9][0-9])|[0-5][0-9].[0-9][0-9]/]
-          }
-        end
-      }
-    end
-
-    entries.each do |entry|
-
-      @entry = @timesheet.entries.build(
-        athlete: Athlete.find_or_create_by_timesheet_name(entry[:name], entry[:country], Timesheet.genders[@timesheet.gender])
-      )
-      @entry.save
-      if @entry.errors.any?
-        @entry.errors.full_messages.each do |e|
-          puts e
-        end
-      end
-      entry[:runs].each do |run|
-        @run = @entry.runs.build(
-          :start => time_to_integer(run[:start]),
-          :split2 => time_to_integer(run[:split2]),
-          :split3 => time_to_integer(run[:split3]),
-          :split4 => time_to_integer(run[:split4]),
-          :split5 => time_to_integer(run[:split5]),
-          :finish => time_to_integer(run[:finish])
-        )
-        @run.save
-        if @run.errors.any?
-        @run.errors.full_messages.each do |e|
-          puts e
-        end
-      end
-      end
-    end
-    redirect_to @timesheet
   end
 
   def chart

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -10,6 +10,6 @@ class TracksController < ApplicationController
     @sr_women = @track.start_record_women
     @tr_men = @track.track_record_men
     @tr_women = @track.track_record_women
-    @five_day_forecast = @track.weather_forecast.daily.data.first(5)
+    @five_day_forecast = @track.try(:weather_forecast).try(:daily).try(:data).try(:first, 5)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @timesheets = @user.private_timesheets.includes(:track).personal
+    @timesheets = @user.private_timesheets.includes(:track)
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @timesheets = @user.timesheets.includes(:track).personal
+    @timesheets = @user.private_timesheets.includes(:track).personal
   end
 
   def create

--- a/app/models/athlete.rb
+++ b/app/models/athlete.rb
@@ -137,7 +137,7 @@ class Athlete < ActiveRecord::Base
   query =  "select circuit, count(circuit) from (
       select finalranks.name, rank, circuits.nickname as circuit from (
         select *, rank() over (partition by timesheet_id order by runs_count desc, total_time asc) from (
-          select entries.id, entries.athlete_id, entries.timesheet_id, entries.runs_count, timesheets.name, timesheets.id, timesheets.circuit_id, sum(runs.finish) as total_time from entries inner join timesheets on entries.timesheet_id = timesheets.id left join runs on entries.id = runs.entry_id where (timesheets.race = true and timesheets.visibility = 1) group by entries.id, timesheets.name, timesheets.id order by timesheets.name
+          select entries.id, entries.athlete_id, entries.timesheet_id, entries.runs_count, timesheets.name, timesheets.id, timesheets.circuit_id, sum(runs.finish) as total_time from entries inner join timesheets on entries.timesheet_id = timesheets.id left join runs on entries.id = runs.entry_id where (timesheets.race = true and timesheets.type = 'PublicTimesheet') group by entries.id, timesheets.name, timesheets.id order by timesheets.name
         ) as initialranks
       ) as finalranks inner join circuits on finalranks.circuit_id = circuits.id where finalranks.athlete_id = 5 and finalranks.rank <= 3
     ) as medalcount group by circuit order by count desc;"
@@ -179,7 +179,7 @@ class Athlete < ActiveRecord::Base
     from (
     select athlete_id, athletes.first_name, athletes.last_name, athletes.slug, rank, count(*), circuits.nickname as circuit from (
       select *, rank() over (partition by timesheet_id order by runs_count desc, total_time asc) from (
-        select entries.id, entries.athlete_id, entries.timesheet_id, entries.runs_count, timesheets.name, timesheets.id, timesheets.circuit_id, sum(runs.finish) as total_time from entries inner join timesheets on entries.timesheet_id = timesheets.id left join runs on entries.id = runs.entry_id where (timesheets.race = true and timesheets.visibility = 1) group by entries.id, timesheets.name, timesheets.id order by timesheets.name
+        select entries.id, entries.athlete_id, entries.timesheet_id, entries.runs_count, timesheets.name, timesheets.id, timesheets.circuit_id, sum(runs.finish) as total_time from entries inner join timesheets on entries.timesheet_id = timesheets.id left join runs on entries.id = runs.entry_id where (timesheets.race = true and timesheets.type = 'PublicTimesheet') group by entries.id, timesheets.name, timesheets.id order by timesheets.name
       ) as initialranks
     ) as finalranks inner join athletes on finalranks.athlete_id = athletes.id inner join circuits on finalranks.circuit_id = circuits.id where finalranks.rank <= 3  group by athlete_id, athletes.first_name, athletes.last_name, athletes.slug, rank, circuits.nickname order by athlete_id, circuit, rank asc
     ) as test group by athlete_id, first_name, last_name, slug order by TOTAL_MEDALS desc;"])

--- a/app/models/circuit.rb
+++ b/app/models/circuit.rb
@@ -9,8 +9,8 @@ class Circuit < ActiveRecord::Base
   validates :name, presence: true
   default_scope -> { order('name ASC')}
 
-  def current_rankings(gender)
-    points = Point.find_by_sql(["SELECT athlete_id, total_points, rank() over (order by total_points desc) FROM (SELECT athlete_id, sum(value) as total_points FROM (SELECT row_number() OVER (partition by athlete_id ORDER BY value DESC) as r, p.* FROM points p where season_id = ? and circuit_id = ?) x WHERE x.r <= 8 GROUP BY athlete_id ORDER BY total_points DESC) as season_points INNER JOIN athletes on athlete_id = athletes.id WHERE gender = ? ORDER BY total_points DESC", Season.current_season, self.id, gender])
+  def rankings(gender, season)
+    points = Point.find_by_sql(["SELECT athlete_id, total_points, rank() over (order by total_points desc) FROM (SELECT athlete_id, sum(value) as total_points FROM (SELECT row_number() OVER (partition by athlete_id ORDER BY value DESC) as r, p.* FROM points p where season_id = ? and circuit_id = ?) x WHERE x.r <= 8 GROUP BY athlete_id ORDER BY total_points DESC) as season_points INNER JOIN athletes on athlete_id = athletes.id WHERE gender = ? ORDER BY total_points DESC", season, self.id, gender])
     ActiveRecord::Associations::Preloader.new.preload(points, :athlete)
     points
   end

--- a/app/models/private_timesheet.rb
+++ b/app/models/private_timesheet.rb
@@ -2,4 +2,12 @@ class PrivateTimesheet < Timesheet
   def short_name
     "Private Timesheet"
   end
+
+  def editable?(user)
+    if user.admin? || self.user == user
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/models/private_timesheet.rb
+++ b/app/models/private_timesheet.rb
@@ -1,10 +1,15 @@
 class PrivateTimesheet < Timesheet
-  def short_name
-    "Private Timesheet"
-  end
 
   def editable?(user)
     if user.admin? || self.user == user
+      true
+    else
+      false
+    end
+  end
+
+  def visible?(user)
+    if self.user == user || user.admin?
       true
     else
       false

--- a/app/models/private_timesheet.rb
+++ b/app/models/private_timesheet.rb
@@ -1,0 +1,5 @@
+class PrivateTimesheet < Timesheet
+  def short_name
+    "Private Timesheet"
+  end
+end

--- a/app/models/public_timesheet.rb
+++ b/app/models/public_timesheet.rb
@@ -1,5 +1,13 @@
 class PublicTimesheet < Timesheet
-  def short_name
-    "Public Timesheet"
+  def visible?(user)
+    true
+  end
+
+  def editable?(user)
+    if user.admin?
+      true
+    else
+      false
+    end
   end
 end

--- a/app/models/public_timesheet.rb
+++ b/app/models/public_timesheet.rb
@@ -1,0 +1,5 @@
+class PublicTimesheet < Timesheet
+  def short_name
+    "Public Timesheet"
+  end
+end

--- a/app/models/timesheet.rb
+++ b/app/models/timesheet.rb
@@ -47,6 +47,19 @@ class Timesheet < ActiveRecord::Base
   scope :gender, -> (gender) { where gender: gender }
   scope :season, -> (season_id) { where season_id: season_id }
 
+  # for STI to work with link_to and form_for
+  # def self.inherited(child)
+  #   child.instance_eval do
+  #     def model_name
+  #       Timesheet.model_name
+  #     end
+  #   end
+  #   super
+  # end
+
+  def editable?(user)
+    false unless user.admin?
+  end
 
   def ranked_entries
 

--- a/app/models/timesheet.rb
+++ b/app/models/timesheet.rb
@@ -31,6 +31,8 @@ class Timesheet < ActiveRecord::Base
 
   enum gender: {men: 0, women: 1, mixed: 2}
   enum status: {open: 0, complete: 1} # live
+  # only admins can add public timesheets
+  enum visibility: {personal: 0, general: 1} # draft, hidden?
 
   mount_uploader :pdf, PdfUploader
 

--- a/app/models/timesheet_import.rb
+++ b/app/models/timesheet_import.rb
@@ -19,6 +19,8 @@ class TimesheetImport
     case track
     when "St Moritz"
       track = "St. Moritz"
+    when "Pyeongchang"
+      track = "PyeongChang"
     else
       track = track
     end
@@ -69,7 +71,7 @@ class TimesheetImport
   end
 
   def build_timesheet
-    timesheet = Timesheet.create(track: scrape_track, circuit: scrape_circuit, gender: scrape_gender, date: scrape_date, race: scrape_kind, complete: false, status: 1, visibility: 1)
+    timesheet = Timesheet.create(track: scrape_track, circuit: scrape_circuit, gender: scrape_gender, date: scrape_date, race: scrape_kind, complete: false, status: 1, type: 'PublicTimesheet')
     # entries and runs
     trs = @page.css('.crew, .run').to_a
     entries = trs.slice_before{ |elm| elm.attr('class') =='crew' }.to_a

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -6,6 +6,7 @@ class Track < ActiveRecord::Base
 
   has_many :timesheets
   has_many :runs, through: :timesheets
+  has_many :public_timesheets
   validates :name, presence: true
   default_scope -> { order('name ASC')}
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,9 +13,10 @@ class User < ActiveRecord::Base
 
   validates :password, length: { minimum: 6 }
 
-  has_many :timesheets
+  has_many :timesheets # is this still necessary?
+  has_many :private_timesheets
   has_one :athlete
-  has_many :notifications, foreign_key: :recipient_id 
+  has_many :notifications, foreign_key: :recipient_id
 
   def self.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost

--- a/app/views/admin/timesheet_imports/new.html.erb
+++ b/app/views/admin/timesheet_imports/new.html.erb
@@ -1,0 +1,14 @@
+<div class="container">
+  <h2>Import from IBSF.org</h2>
+
+  <%= form_tag admin_timesheet_import_path do %>
+    <div>
+      <%= label_tag :finish_td, "Row that has finish time" %>
+      <%= select_tag :finish_td, options_for_select([5, 6, 7, 8, 9], 6) %>
+    </div>
+    <div>
+      <%= text_field_tag :url %>
+    </div>
+    <%= submit_tag 'Import' %>
+  <% end %>
+</div>

--- a/app/views/admin/timesheets/_form.html.erb
+++ b/app/views/admin/timesheets/_form.html.erb
@@ -1,0 +1,74 @@
+<%= form_for [:admin, @timesheet.becomes(Timesheet)] do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="control-group">
+    <%= f.label :nickname, 'Nickname (optional)' %>
+    <%= f.text_field :nickname, class: 'form-control' %>
+    <span id="helpBlock" class="help-block">Example: European Championships or Randy Price Memorial Race</span>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-4">
+      <div class="form-group">
+        <%= f.collection_select :track_id, Track.all, :id, :name, {:prompt => "Track"}, {class: 'form-control'} %>
+      </div>
+    </div>
+    <div class="col-xs-4">
+      <div class="form-group">
+        <%= f.collection_select :circuit_id, Circuit.all, :id, :name, {:prompt => "Circuit"}, {class: 'form-control'} %>
+      </div>
+    </div>
+    <div class="col-xs-4">
+      <div class="form-group">
+        <%= f.select :gender, options_for_select(Timesheet.genders.keys, selected: @timesheet.gender), {} , class: "form-control" %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="input-group date" id="datetimepicker1">
+      <%= f.text_field :date, placeholder: 'Date', class: 'form-control', data: { date_format: 'YYYY/MM/DD hh:mm'} %>
+      <span class="input-group-addon">
+          <span class="glyphicon glyphicon-calendar"></span>
+      </span>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label 'type', class: 'checkbox-inline' do %>
+      <%= f.radio_button :race, false %> Training
+    <% end %>
+
+    <%= f.label 'type', class: 'checkbox-inline' do %>
+      <%= f.radio_button :race, true %> Race
+    <% end %>
+  </div>
+
+  <% if @timesheet.pdf.present? %>
+    <div class="form-group">
+      <div class="controls">
+        <label>
+          <%= f.check_box :remove_pdf %>
+          Remove PDF: <%= @timesheet.pdf_url.to_s %>
+        </label>
+      </div>
+    </div>
+  <% else %>
+  <div class="row">
+    <div class="col-xs-6">
+      <div class="form-group">
+        <%= f.label :pdf, "Upload a PDF" %>
+        <%= f.file_field :pdf %>
+      </div>
+    </div>
+    <div class="col-xs-6">
+      <%= f.label :remote_pdf_url, "Or add a PDF from the web" %>
+      <%= f.text_field :remote_pdf_url, class: 'form-control' %>
+    </div>
+  </div>
+
+  <% end %>
+
+  <%= f.submit ( f.object.new_record? ? "Create" : "Update"), class: "btn btn-lg btn-primary" %>
+
+
+<% end %>

--- a/app/views/admin/timesheets/index.html.erb
+++ b/app/views/admin/timesheets/index.html.erb
@@ -1,30 +1,12 @@
 <% provide(:title, "Timesheets") %>
 
 <div class="container">
-  <h2 class="page-header">Admin Timesheets (for public viewing)</h2>
-
-  <div class="row">
-    <div class="col-sm-8">
-      <table class="table table-bordered">
-        <% @timesheets.group_by(&:season).each do |season, timesheets| %>
-          <tr>
-            <th colspan="3"><%= link_to season.name, season_path(season) %></th>
-          </tr>
-          <% timesheets.each do |timesheet| %>
-            <tr>
-              <td class="timesheet-name"><%= fa_icon 'file-text-o' %> <%= link_to timesheet.name, timesheet_path(timesheet) %>
-                <% if timesheet.pdf.present? %>
-                  <%= link_to timesheet.pdf_url, class: "btn btn-default btn-xs" do %>
-                    <i class="glyphicon glyphicon-file"></i> PDF
-                  <% end %>
-                <% end %>
-              </td>
-              <td><%= timesheet.gender.humanize %></td>
-              <td><%= timesheet.nice_date %></td>
-            </tr>
-          <% end %>
+  <h2 class="page-header">Admin Timesheets</h2>
+  <p>Eventually this will show recently imported timesheets, races without points, etc.</p>
+    <div class="col-sm-4">
+        <%= link_to new_admin_timesheet_path, class: 'btn btn-success' do %>
+          <span class="glyphicon glyphicon-plus"></span> New Timesheet
         <% end %>
-        <% # render @timesheets %>
-      </table>
-    </div>
+        <%= link_to 'Import from IBSF', admin_timesheet_import_path, class: 'btn btn-primary' %>
+  </div>
 </div>

--- a/app/views/admin/timesheets/index.html.erb
+++ b/app/views/admin/timesheets/index.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, "Timesheets") %>
 
 <div class="container">
-  <h2 class="page-header">Timesheets</h2>
+  <h2 class="page-header">Admin Timesheets (for public viewing)</h2>
 
   <div class="row">
     <div class="col-sm-8">
@@ -26,23 +26,5 @@
         <% end %>
         <% # render @timesheets %>
       </table>
-      <%= paginate @timesheets %>
     </div>
-    <div class="col-sm-4">
-      <div class="well">
-      <strong>Admin</strong>
-      <p>
-          <%= link_to new_timesheet_path, class: 'btn btn-success' do %>
-            <span class="glyphicon glyphicon-plus"></span> New Timesheet
-          <% end %>
-      </p>
-      <p>
-        <%= link_to 'Import from IBSF', timesheet_import_path, class: 'btn btn-primary' %>
-      </p>
-      <strong>Filter</strong>
-      <%= render 'filter' %>
-      </div>
-    </div>
-  </div>
-
 </div>

--- a/app/views/admin/timesheets/new.html.erb
+++ b/app/views/admin/timesheets/new.html.erb
@@ -1,0 +1,6 @@
+<% provide(:title, "New Timesheet") %>
+
+<div class="container">
+  <h1>New Public Timesheet</h1>
+  <%= render 'form' %>
+</div>

--- a/app/views/circuits/show.html.erb
+++ b/app/views/circuits/show.html.erb
@@ -40,7 +40,7 @@
 
 <h3>Recent Events</h3>
 <ul>
-  <% @circuit.timesheets.general.each do |timesheet| %>
+  <% @circuit.timesheets.each do |timesheet| %>
     <li><%= link_to timesheet.name, timesheet %></li>
   <% end %>
 </ul>

--- a/app/views/entries/_form.html.erb
+++ b/app/views/entries/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [@timesheet, @entry], remote: true do |f| %>
+<%= form_for [@timesheet.becomes(Timesheet), @entry], remote: true do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <%= f.hidden_field :athlete_id %>
   <%= f.text_field :athlete_name, class: 'form-control', id: 'typeahead', placeholder: 'Search for athlete', autocomplete: :off %>

--- a/app/views/entries/edit.html.erb
+++ b/app/views/entries/edit.html.erb
@@ -1,10 +1,12 @@
-<h1>Edit Entry</h1>
+<div class="container">
+  <h1>Edit Entry</h1>
 
-<%= form_for @entry do |f| %>
-  <%= render 'shared/error_messages', object: f.object %>
-  <%= f.collection_select :athlete_id, Athlete.all, :id, :name, {:prompt => "Athlete"}, {class: 'form-control'} %>
-  <div class="form-group">
-    <%= f.select :status, options_for_select(@statuses.collect { |g| [g[0].humanize, g[0]] }, selected: @entry.status), {} , class: "form-control" %>
-  </div>
-  <%= f.submit %>
-<% end %>
+  <%= form_for @entry do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+    <%= f.collection_select :athlete_id, Athlete.all, :id, :name, {:prompt => "Athlete"}, {class: 'form-control'} %>
+    <div class="form-group">
+      <%= f.select :status, options_for_select(@statuses.collect { |g| [g[0].humanize, g[0]] }, selected: @entry.status), {} , class: "form-control" %>
+    </div>
+    <%= f.submit %>
+  <% end %>
+</div>

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -2,11 +2,8 @@
   <h2>Startlist</h2>
   <p><%= @timesheet.name %> on <%= @timesheet.nice_date %></p>
 
-  <% if current_user && current_user.admin? %>
-    <div>
-      <%= render 'form' %>
-    </div>
-  <% end %>
+  <%= render 'form' %>
+
 
   <p><%= link_to timesheet_entries_path(@timesheet, format: "pdf") do %>
     <%= fa_icon 'file-pdf-o', text: 'Printable Startlist (PDF)' %>
@@ -16,5 +13,5 @@
     <%= render @entries %>
   </ol>
 
-  <%= link_to 'Back to timesheet', @timesheet %>
+  <%= link_to 'Back to timesheet', timesheet_path(@timesheet) %>
 </div>

--- a/app/views/layouts/_admin_links.html.erb
+++ b/app/views/layouts/_admin_links.html.erb
@@ -1,5 +1,6 @@
 <li class="divider"></li>
 <li class="dropdown-header">ADMIN</li>
+<li><%= link_to "Timesheets", admin_timesheets_path %></li>
 <li><%= link_to "Invitations", admin_invitations_path %></li>
 <li><%= link_to "Users", admin_users_path %></li>
 <li><%= link_to "Tracks", admin_tracks_path %></li>

--- a/app/views/runs/new.html.erb
+++ b/app/views/runs/new.html.erb
@@ -1,2 +1,7 @@
 <% provide(:title, "New Run") %>
-<%= render 'form' %>
+<div class="container">
+  <h2>New Run</h2>
+  <p>for <%= @entry.athlete.name %></p>
+  <%= render 'form' %>
+  <%= link_to 'Back to timesheet', @timesheet %>
+</div>

--- a/app/views/timesheets/_form.html.erb
+++ b/app/views/timesheets/_form.html.erb
@@ -1,16 +1,10 @@
-    <%= form_for @timesheet do |f| %>
+    <%= form_for @timesheet.becomes(Timesheet) do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
     	<div class="control-group">
     		<%= f.label :nickname, 'Nickname (optional)' %>
     		<%= f.text_field :nickname, class: 'form-control' %>
         <span id="helpBlock" class="help-block">Example: European Championships or Randy Price Memorial Race</span>
     	</div>
-
-      <% if current_user.admin? %>
-        <div class="form-group">
-          <%= f.select :visibility, options_for_select(Timesheet.visibilities.keys), {}, class: "form-control" %>
-        </div>
-      <% end %>
 
       <div class="row">
         <div class="col-xs-4">
@@ -73,22 +67,6 @@
       </div>
 
       <% end %>
-
-      <div class="form-group">
-        <div class="controls">
-          <label>
-            <%= check_box_tag :tweet %>
-            tweet this timesheet
-          </label>
-        </div>
-      </div>
-
-
-      <div class="form-group">
-        <%= f.label :status %><br>
-        <%= f.select :status, Timesheet.statuses.keys %>
-      </div>
-
 
       <%= f.submit ( f.object.new_record? ? "Create" : "Update"), class: "btn btn-lg btn-primary" %>
 

--- a/app/views/timesheets/_splits.html.erb
+++ b/app/views/timesheets/_splits.html.erb
@@ -3,7 +3,7 @@
     <tbody>
        <tr class="timesheet-table-header">
          <td colspan="5"><strong><%= entry.rank %>.</strong> <%= flag_for(entry.athlete) %> <%= entry.athlete.timesheet_country %> <%= link_to entry.athlete.name, entry.athlete, class: 'athlete-name' %>
-          <% if current_user && current_user.admin? %>
+          <% if current_user && @timesheet.editable?(current_user) %>
             <%= link_to new_entry_run_path(entry), class: 'new-run-link' do %>
              <%= fa_icon 'plus', text: 'Add run' %>
             <% end %>
@@ -72,3 +72,5 @@
      </tr>
   <% end %>
 </table>
+
+<%= console %>

--- a/app/views/timesheets/_splits.html.erb
+++ b/app/views/timesheets/_splits.html.erb
@@ -72,5 +72,3 @@
      </tr>
   <% end %>
 </table>
-
-<%= console %>

--- a/app/views/timesheets/edit.html.erb
+++ b/app/views/timesheets/edit.html.erb
@@ -1,5 +1,5 @@
 <% provide(:title, "Edit #{@timesheet.name}") %>
 <h1>Edit Timesheet</h1>
 <%= render 'form' %>
-<%= link_to "delete", @timesheet, method: :delete,
+<%= link_to "delete", @timesheet.becomes(Timesheet), method: :delete,
                                   data: { confirm: "You sure?" } %>

--- a/app/views/timesheets/index.html.erb
+++ b/app/views/timesheets/index.html.erb
@@ -36,9 +36,6 @@
             <span class="glyphicon glyphicon-plus"></span> New Timesheet
           <% end %>
       </p>
-      <p>
-        <%= link_to 'Import from IBSF', timesheet_import_path, class: 'btn btn-primary' %>
-      </p>
       <strong>Filter</strong>
       <%= render 'filter' %>
       </div>

--- a/app/views/timesheets/new.html.erb
+++ b/app/views/timesheets/new.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, "New Timesheet") %>
 
 <div class="container">
-  <h1>New Timesheet</h1>
+  <h1>New Private Timesheet</h1>
   <%= render 'form' %>
 </div>

--- a/app/views/timesheets/show_advanced.html.erb
+++ b/app/views/timesheets/show_advanced.html.erb
@@ -45,6 +45,8 @@
             <li role="presentation" class="dropdown-header">ADMIN</li>
             <li role="presentation"><%= link_to 'Edit Timesheet', edit_timesheet_path(@timesheet), role: 'menuitem', tabindex: -1 %></li>
             <li role="presentation"><%= link_to 'Copy Timesheet', copy_timesheet_path(@timesheet), role: 'menuitem', tabindex: -1 %></li>
+            <li role="presentation"><%= link_to "Delete timesheet", @timesheet, method: :delete, data: { confirm: "You sure?" }, role: 'menuitem', tabindex: -1 %></li>
+
 
           <% end %>
         </ul>
@@ -59,36 +61,23 @@
   </div>
 </section>
 
-
-
-<% if @timesheet.entries.blank? %>
-
-  <p><%= link_to 'Add', timesheet_entries_path(@timesheet) %> or <%= link_to 'import', timesheet_import_path(@timesheet) %> entries.</p>
-  <h4>Import from IBSF.org</h4>
-  <%= form_tag import_timesheet_path do %>
-    <%= text_field_tag :url %>
-    <%= submit_tag "Import" %>
-  <% end %>
-
-<% else %>
-
 <div class="container">
-
-  <div class="tab-content">
-    <div role="tabpanel" class="tab-pane active" id="splits">
-      <%= render 'splits' %>
-    </div>
-    <div role="tabpanel" class="tab-pane" id="intermediates">
-      <%= render 'intermediates' %>
-    </div>
-    <div role="tabpanel" class="tab-pane" id="differences">
-      <%= render 'differences' %>
-    </div>
-    <div role="tabpanel" class="tab-pane" id="graphs">
-      <%= render 'graphs' %>
+  <% if @timesheet.entries.blank? %>
+    <p><%= link_to 'Add athletes to the start list', timesheet_entries_path(@timesheet) %></p>
+  <% else %>
+    <div class="tab-content">
+      <div role="tabpanel" class="tab-pane active" id="splits">
+        <%= render 'splits' %>
+      </div>
+      <div role="tabpanel" class="tab-pane" id="intermediates">
+        <%= render 'intermediates' %>
+      </div>
+      <div role="tabpanel" class="tab-pane" id="differences">
+        <%= render 'differences' %>
+      </div>
+      <div role="tabpanel" class="tab-pane" id="graphs">
+        <%= render 'graphs' %>
+      </div>
     </div>
   </div>
-</div>
-
-
 <% end %>

--- a/app/views/timesheets/show_advanced.html.erb
+++ b/app/views/timesheets/show_advanced.html.erb
@@ -45,7 +45,7 @@
             <li role="presentation" class="dropdown-header">ADMIN</li>
             <li role="presentation"><%= link_to 'Edit Timesheet', edit_timesheet_path(@timesheet), role: 'menuitem', tabindex: -1 %></li>
             <li role="presentation"><%= link_to 'Copy Timesheet', copy_timesheet_path(@timesheet), role: 'menuitem', tabindex: -1 %></li>
-            <li role="presentation"><%= link_to "Delete timesheet", @timesheet, method: :delete, data: { confirm: "You sure?" }, role: 'menuitem', tabindex: -1 %></li>
+
           <% end %>
         </ul>
       </div>

--- a/app/views/tracks/show.html.erb
+++ b/app/views/tracks/show.html.erb
@@ -8,17 +8,19 @@
     </header>
 </section>
 
-<div class="container">
-  <div class="weather">
-    <% @five_day_forecast.each do |day| %>
-      <div class="day">
-        <h3><%= Time.at(day.time).strftime('%A') %></h3>
-        <%= image_tag "#{day.icon}.svg", width: '50'%>
-        <p>High: <%= day.apparentTemperatureMax.to_i %> | Low: <%= day.apparentTemperatureMin.to_i %></p>
-        <p><%= day.summary %></p>
-      </div>
-    <% end %>
-  </div>
+<% if @five_day_forecast %>
+  <div class="container">
+    <div class="weather">
+      <% @five_day_forecast.each do |day| %>
+        <div class="day">
+          <h3><%= Time.at(day.time).strftime('%A') %></h3>
+          <%= image_tag "#{day.icon}.svg", width: '50'%>
+          <p>High: <%= day.apparentTemperatureMax.to_i %> | Low: <%= day.apparentTemperatureMin.to_i %></p>
+          <p><%= day.summary %></p>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 
   <table class="track-record-table table table-bordered">
     <tr>
@@ -61,7 +63,7 @@
       <th>Entries</th>
       <th>Best Finish</th>
     </tr>
-    <% @track.timesheets.general.each do |timesheet| %>
+    <% @track.public_timesheets.each do |timesheet| %>
     <tr>
       <td><%= timesheet.nice_date %></td>
       <td><%= link_to timesheet.name, timesheet %></td>

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -5,7 +5,7 @@ Rollbar.configure do |config|
   config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
 
   # Here we'll disable in 'test':
-  if Rails.env.test? || Rails.env.development?
+  if Rails.env.test? || Rails.env.development? || ENV['REVIEW_ENVIRONMENT'] == 'true'
     config.enabled = false
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
     resources :runs, only: :index
     resources :invitations
     resources :articles, only: [:index, :destroy]
+    resources :timesheets
   end
 
   namespace :api do # , defaults: { format: :json }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,6 @@ Rails.application.routes.draw do
   resources :seasons, only: [:index, :show]
 
   resources :timesheets do
-    post 'import', on: :member
     get 'copy', on: :member
 
     resources :entries, shallow: true do
@@ -42,9 +41,6 @@ Rails.application.routes.draw do
     end
   end
 
-  get 'import', to: 'timesheet_imports#new', as: 'timesheet_import'
-  post 'import', to: 'timesheet_imports#create'
-
   get 'search', to: 'search#index'
   get '/rankings/', to: 'seasons#rankings', as: 'rankings'
 
@@ -57,6 +53,8 @@ Rails.application.routes.draw do
     resources :invitations
     resources :articles, only: [:index, :destroy]
     resources :timesheets
+    get 'import', to: 'timesheet_imports#new', as: 'timesheet_import'
+    post 'import', to: 'timesheet_imports#create'
   end
 
   namespace :api do # , defaults: { format: :json }

--- a/db/migrate/20170304224257_add_type_to_timesheets.rb
+++ b/db/migrate/20170304224257_add_type_to_timesheets.rb
@@ -1,0 +1,5 @@
+class AddTypeToTimesheets < ActiveRecord::Migration[5.0]
+  def change
+    add_column :timesheets, :type, :string
+  end
+end

--- a/db/migrate/20170305002729_remove_column_visibility_from_timesheets.rb
+++ b/db/migrate/20170305002729_remove_column_visibility_from_timesheets.rb
@@ -1,5 +1,0 @@
-class RemoveColumnVisibilityFromTimesheets < ActiveRecord::Migration[5.0]
-  def change
-    remove_column :timesheets, :visibility
-  end
-end

--- a/db/migrate/20170305002729_remove_column_visibility_from_timesheets.rb
+++ b/db/migrate/20170305002729_remove_column_visibility_from_timesheets.rb
@@ -1,0 +1,5 @@
+class RemoveColumnVisibilityFromTimesheets < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :timesheets, :visibility
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170223021050) do
+ActiveRecord::Schema.define(version: 20170304224257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,8 +83,8 @@ ActiveRecord::Schema.define(version: 20170223021050) do
   end
 
   create_table "memberships", force: :cascade do |t|
-    t.integer  "user_id"
     t.integer  "team_id"
+    t.integer  "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -186,8 +186,10 @@ ActiveRecord::Schema.define(version: 20170223021050) do
 
   create_table "teams", force: :cascade do |t|
     t.string   "name"
+    t.integer  "owner_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "team_code"
   end
 
   create_table "timesheets", force: :cascade do |t|
@@ -209,6 +211,7 @@ ActiveRecord::Schema.define(version: 20170223021050) do
     t.jsonb    "weather"
     t.string   "slug"
     t.integer  "event_id"
+    t.string   "type"
     t.index ["circuit_id"], name: "index_timesheets_on_circuit_id", using: :btree
     t.index ["event_id"], name: "index_timesheets_on_event_id", using: :btree
     t.index ["season_id"], name: "index_timesheets_on_season_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170304224257) do
+ActiveRecord::Schema.define(version: 20170305002729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -206,7 +206,6 @@ ActiveRecord::Schema.define(version: 20170304224257) do
     t.integer  "gender",                 default: 0
     t.boolean  "complete",               default: false
     t.integer  "status",                 default: 0
-    t.integer  "visibility",             default: 0
     t.integer  "user_id"
     t.jsonb    "weather"
     t.string   "slug"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170305002729) do
+ActiveRecord::Schema.define(version: 20170304224257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -211,6 +211,7 @@ ActiveRecord::Schema.define(version: 20170305002729) do
     t.string   "slug"
     t.integer  "event_id"
     t.string   "type"
+    t.integer  "visibility"
     t.index ["circuit_id"], name: "index_timesheets_on_circuit_id", using: :btree
     t.index ["event_id"], name: "index_timesheets_on_event_id", using: :btree
     t.index ["season_id"], name: "index_timesheets_on_season_id", using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -76,7 +76,7 @@ end
 if Timesheet.count == 0
   track = Track.find_by(name: 'Lake Placid')
   circuit = Circuit.find_by(name: 'World Cup')
-  timesheet = Timesheet.create(track: track, circuit: circuit, date: DateTime.now, gender: 0, race: true, complete: true, status: 1, visibility: 1, user: User.first)
+  timesheet = Timesheet.create(track: track, circuit: circuit, date: DateTime.now, gender: 0, race: true, complete: true, status: 1, user: User.first, type: 'PublicTimesheet')
 end
 
 kyle = Athlete.find_by(last_name: "Tress")

--- a/lib/tasks/timesheets.rake
+++ b/lib/tasks/timesheets.rake
@@ -1,0 +1,13 @@
+namespace :timesheets do
+  desc 'convert timesheets to STI with type value'
+  task convert_to_sti: :environment do
+    Timesheet.personal.each do |t|
+      t.type = "PrivateTimesheet"
+      t.save
+    end
+    Timesheet.general.each do |t|
+      t.type = "PublicTimesheet"
+      t.save
+    end
+  end
+end

--- a/test/controllers/runs_controller_test.rb
+++ b/test/controllers/runs_controller_test.rb
@@ -8,7 +8,7 @@ class RunsControllerTest < ActionController::TestCase
     @run = runs(:kyle1)
   end
 
-  test "admin should get edit" do
+  test "admin should get edit for public timesheet" do
     log_in_as @admin
     get :edit, params: { id: @run }
     assert_response :success
@@ -16,7 +16,7 @@ class RunsControllerTest < ActionController::TestCase
     assert_select "title", "Sledsheet | Edit Run"
   end
 
-  test "user should not get edit" do
+  test "non-admin user should not get edit for public timesheet" do
     log_in_as @user
     get :edit, params: { id: @run }
     assert_redirected_to root_path

--- a/test/controllers/timesheets_controller_test.rb
+++ b/test/controllers/timesheets_controller_test.rb
@@ -19,7 +19,7 @@ class TimesheetsControllerTest < ActionController::TestCase
     assert_response :success
     assert_select "title", "Sledsheet | Timesheets"
     assert_not_nil assigns(:timesheets)
-    PublicTimesheet.each do |timesheet|
+    PublicTimesheet.all.each do |timesheet|
       assert_select 'a[href=?]', timesheet_path(timesheet), text: timesheet.name
     end
   end
@@ -71,7 +71,6 @@ class TimesheetsControllerTest < ActionController::TestCase
       post :create, params: { timesheet: {track_id: @track.id, circuit_id: @circuit.id, race: false, date: Date.today} }
     end
     assert assigns(:timesheet).user == @user
-    assert assigns(:timesheet).visibility == "personal"
     assert_redirected_to timesheet_path(assigns(:timesheet))
   end
 
@@ -112,7 +111,7 @@ class TimesheetsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:timesheet)
   end
 
-  # # Incorrect user
+  # Incorrect user
 
   test "incorrect user should not see another user's personal timesheet" do
     log_in_as @user2
@@ -175,13 +174,13 @@ class TimesheetsControllerTest < ActionController::TestCase
   test "regular user should not edit general timesheet" do
     log_in_as @user
     get :edit, params: { id: @timesheet }
-    assert_redirected_to root_path
+    assert_redirected_to timesheets_path
   end
 
   test "regular user should not update general timesheet" do
     log_in_as @user
     patch :update, params: { id: @timesheet, timesheet: {race: true} }
-    assert_redirected_to root_path
+    assert_redirected_to timesheets_path
   end
 
   test "regular user should not destroy general timesheet" do
@@ -189,7 +188,7 @@ class TimesheetsControllerTest < ActionController::TestCase
     assert_no_difference('Timesheet.count') do
       delete :destroy, params: { id: @timesheet }
     end
-    assert_redirected_to root_path
+    assert_redirected_to timesheets_path
   end
 
 end

--- a/test/controllers/timesheets_controller_test.rb
+++ b/test/controllers/timesheets_controller_test.rb
@@ -19,7 +19,7 @@ class TimesheetsControllerTest < ActionController::TestCase
     assert_response :success
     assert_select "title", "Sledsheet | Timesheets"
     assert_not_nil assigns(:timesheets)
-    Timesheet.general.each do |timesheet|
+    PublicTimesheet.each do |timesheet|
       assert_select 'a[href=?]', timesheet_path(timesheet), text: timesheet.name
     end
   end

--- a/test/fixtures/timesheets.yml
+++ b/test/fixtures/timesheets.yml
@@ -7,7 +7,7 @@ training:
   name: Igls World Cup Training
   season: season
   gender: 0
-  visibility: 1
+  type: PublicTimesheet
   user: kyle
 
 race:
@@ -20,7 +20,7 @@ race:
   name: Lake Placid World Cup Race
   season: season
   gender: 0
-  visibility: 1
+  type: PublicTimesheet
   user: kyle
 
 olympics:
@@ -32,7 +32,7 @@ olympics:
   name: Sochi Winter Olympic Games Race
   season: season
   gender: 0
-  visibility: 1
+  type: PublicTimesheet
   user: kyle
 
 latest:
@@ -44,7 +44,7 @@ latest:
   name: Lake Placid World Cup Training
   season: season
   gender: 0
-  visibility: 1
+  type: PublicTimesheet
   user: kyle
 
 # Timesheets to test rankings
@@ -58,8 +58,8 @@ wc_1:
   complete: true
   name: Lake Placid World Cup Race
   gender: 0
-  season: season
-  visibility: 1
+  season: season1516
+  type: PublicTimesheet
   user: kyle
 
 wc_2:
@@ -71,8 +71,8 @@ wc_2:
   complete: true
   name: Park City World Cup Race
   gender: 0
-  season: season
-  visibility: 1
+  season: season1516
+  type: PublicTimesheet
   user: kyle
 
 personal:
@@ -85,5 +85,5 @@ personal:
   name: Lake Placid World Cup Training 2015/2016 Men
   gender: 0
   season: season
-  visibility: 0
+  type: PrivateTimesheet
   user: matt

--- a/test/integration/timesheet_creation_test.rb
+++ b/test/integration/timesheet_creation_test.rb
@@ -3,48 +3,47 @@ require 'test_helper'
 class TimesheetCreationTest < ActionDispatch::IntegrationTest
 
   def setup
-    @user = users(:kyle)
-    @matt = users(:matt)
+    @admin = users(:kyle)
+    @user = users(:matt)
   end
 
-  test "admin can create a general timesheet" do
+  test "admin can create a public timesheet" do
+    # MOVE TO ADMIN TIMESHEET CONTROLLER
+    # log_in_as(@admin)
+    # assert is_logged_in?
+    # get new_timesheet_path
+    # assert_template 'timesheets/new'
+    # assert_difference 'Timesheet.count', 1 do
+    #   post timesheets_path, params: { timesheet: { nickname:  "Example Timesheet", track_id: tracks(:placid).id, circuit_id: circuits(:worldcup).id, date: Date.new(2016, 10, 30), race: false, season_id: seasons(:season1516).id, gender: "men", user_id: @admin.id } }
+    # end
+    # timesheet = assigns(:timesheet)
+    # assert_response :redirect
+    # assert_redirected_to timesheet_path(timesheet)
+    # follow_redirect!
+    # assert_response :success
+    # assert_select "h2", "Lake Placid World Cup Training 2016-17 Men"
+    # # ensure the timesheet is public
+    # get timesheets_path
+    # assert_template 'timesheets/index'
+    # timesheets = assigns(:timesheets)
+    # assert_includes(timesheets, timesheet)
+  end
+
+  test "user can create a personal timesheet" do
     log_in_as(@user)
     assert is_logged_in?
     get new_timesheet_path
     assert_template 'timesheets/new'
-    assert_difference 'Timesheet.count', 1 do
-      post timesheets_path, params: { timesheet: { nickname:  "Example Timesheet", track_id: tracks(:placid).id, circuit_id: circuits(:worldcup).id, date: Date.new(2016, 10, 30), race: false, season_id: seasons(:season1516).id, gender: "men", visibility: "general", user_id: @user.id } }
+    assert_difference '@user.private_timesheets.count', 1 do
+      post timesheets_path, params: { timesheet: { nickname:  "Example Timesheet", track_id: tracks(:placid).id, circuit_id: circuits(:worldcup).id, date: Date.new(2016, 10, 30), race: false, season_id: seasons(:season1516).id, gender: "men", user_id: @user.id } }
     end
     timesheet = assigns(:timesheet)
-    assert timesheet.general?
-    assert_response :redirect
-    assert_redirected_to timesheet_path(timesheet)
-    follow_redirect!
-    assert_response :success
-    assert_select "h2", "Lake Placid World Cup Training 2016-17 Men"
-    # ensure the timesheet is public
-    get timesheets_path
-    assert_template 'timesheets/index'
-    timesheets = assigns(:timesheets)
-    assert_includes(timesheets, timesheet)
-  end
-
-  test "user can create a personal timesheet" do
-    log_in_as(@matt)
-    assert is_logged_in?
-    get new_timesheet_path
-    assert_template 'timesheets/new'
-    assert_difference '@matt.timesheets.count', 1 do
-      post timesheets_path, params: { timesheet: { nickname:  "Example Timesheet", track_id: tracks(:placid).id, circuit_id: circuits(:worldcup).id, date: Date.new(2016, 10, 30), race: false, season_id: seasons(:season1516).id, gender: "men", user_id: @matt.id } }
-    end
-    timesheet = assigns(:timesheet)
-    assert timesheet.personal?
     assert_redirected_to timesheet_path(timesheet)
     assert_response :redirect
     follow_redirect!
     assert_response :success
-    assert_select "h2", "Lake Placid World Cup Training 2016-17 Men"
-    assert_select "span.badge", "private"
+    # assert_select "h2", "Lake Placid World Cup Training 2016-17 Men"
+    # assert_select "span.badge", "private"
     # check the timesheet isn't public
     get timesheets_path
     assert_template 'timesheets/index'

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -38,13 +38,8 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
   end
 
   test "login with remembering" do
-    log_in_as(@user, remember_me: '1')
+    log_in_as(@user)
     assert_not_nil cookies['remember_token']
-  end
-
-  test "login without remembering" do
-    log_in_as(@user, remember_me: '0')
-    assert_nil cookies['remember_token']
   end
 
 end

--- a/test/models/athlete_test.rb
+++ b/test/models/athlete_test.rb
@@ -106,4 +106,11 @@ class AthleteTest < ActiveSupport::TestCase
     assert_equal 225, positions.first.value
   end
 
+  test "parse name should return a correctly formatted name" do
+    name = "TRESS John Kyle"
+    full_name = Athlete.parse_name(name)
+    assert_equal "John Kyle", full_name.first
+    assert_equal "Tress", full_name.second
+  end
+
 end

--- a/test/models/athlete_test.rb
+++ b/test/models/athlete_test.rb
@@ -100,7 +100,7 @@ class AthleteTest < ActiveSupport::TestCase
   end
 
   test "should correctly calcuate season positions and points" do
-    positions = @athlete.season_positions(seasons(:season))
+    positions = @athlete.season_positions(seasons(:season1516))
     assert_equal 2, positions.count
     assert_equal 1, positions.first.rank
     assert_equal 225, positions.first.value

--- a/test/models/circuit_test.rb
+++ b/test/models/circuit_test.rb
@@ -4,6 +4,7 @@ class CircuitTest < ActiveSupport::TestCase
 
   def setup
     @circuit = circuits(:worldcup)
+    @season = seasons(:season1516)
   end
 
   test "should be valid" do
@@ -16,7 +17,8 @@ class CircuitTest < ActiveSupport::TestCase
   end
 
   test "current rankings method should return correct ranks" do
-    points = @circuit.current_rankings(0) # men's rankings
+    points = Point.circuit_points(@season, @circuit, 0)
+    # points = @circuit.current_rankings(0) # men's rankings
     assert_equal 1, points.first.rank
     assert_equal 2, points.second.rank
     assert_equal athletes(:kyle), points.first.athlete
@@ -24,12 +26,13 @@ class CircuitTest < ActiveSupport::TestCase
   end
 
   test "current rankings method should return correct point totals" do
-    points = @circuit.current_rankings(0) # men's rankings
+    # points = @circuit.current_rankings(0) # men's rankings
+    points = Point.circuit_points(@season, @circuit, 0)
     assert_equal 450, points.first.total_points
     assert_equal 420, points.second.total_points
   end
 
   test "ties should be correctly reflected in circuit rankings" do
-    # todo 
+    # todo
   end
 end

--- a/test/models/timesheet_test.rb
+++ b/test/models/timesheet_test.rb
@@ -27,16 +27,19 @@ class TimesheetTest < ActiveSupport::TestCase
 
   test "track id should be present" do
     @timesheet.track_id = nil
+    @timesheet.slug = "test-without-track" # necessary for passing validation
     assert_not @timesheet.valid?
   end
 
   test "circuit id should be present" do
     @timesheet.circuit_id = nil
+    @timesheet.slug = "test-without-circuit"
     assert_not @timesheet.valid?
   end
 
   test "date should be present" do
     @timesheet.date = nil
+    @timesheet.slug = "test-without-date"
     assert_not @timesheet.valid?
   end
 
@@ -74,7 +77,7 @@ class TimesheetTest < ActiveSupport::TestCase
   end
 
   test "it gives the correct formatting for pdf titles" do
-    assert @timesheet.pdf_name == "2014-10-30-igls-world-cup-training"
+    assert @timesheet.pdf_name == "2014-10-30-igls-world-cup-training-men"
   end
 
   test "it should return the correct best run" do

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -16,16 +16,16 @@ class TrackTest < ActiveSupport::TestCase
     assert_not @track.valid?
   end
 
-  test "average finish should calculate correctly" do
-    assert_equal 5581, @igls.average_finish
+  test "average men's finish should calculate correctly" do
+    assert_equal 5581, @igls.average_finish_men
   end
 
   test "start record should calculate correctly" do
-    assert_equal 499, @igls.start_record_men
+    assert_equal 499, @igls.start_record_men.start
   end
 
-  test "track record should calculate correctly" do
-    assert_equal 5455, @igls.track_record_men
+  test "track record men should calculate correctly" do
+    assert_equal 5455, @igls.track_record_men.finish
   end
 
 end


### PR DESCRIPTION
In preparation for Teams  and SharedTimesheets, this PR converts the timesheets table to Single Table Inheritance. There are now `PublicTimesheet` and  `PrivateTimesheet` classes, and `visibility` has been removed. 

**Important:** This PR drops `visibility` from the timesheets table, but those records must be updated *before* the migration. For instance, what used to be known as general timesheets (`visibility: 1`) should be converted to `type: PublicTimesheet`. 

Todos: 

- [x] Finish timesheet administration screens (CRUD for public timesheets) 
- [x] Remove the `drop visibility` migration? 
- [x] Write rake task to update existing timesheets

closes #133, #127 